### PR TITLE
Bump version to v0.6.2 for patching substrate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmi"
-version = "0.7.0"
+version = "0.6.2"
 edition = "2018"
 authors = ["Nikolay Volf <nikvolf@gmail.com>", "Svyatoslav Nikolsky <svyatonik@yandex.ru>", "Sergey Pepyakin <s.pepyakin@gmail.com>"]
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
## Desc

Substrate currently using wasmi 0.6.2, for pathcing wasmi for all substrate wasmi dependencies, bump version to 0.6.2